### PR TITLE
add dynamic and lazy-loading earthkit imports

### DIFF
--- a/src/earthkit/__int__.py
+++ b/src/earthkit/__int__.py
@@ -1,0 +1,49 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import importlib
+import pkgutil
+import threading
+
+try:
+    from earthkit._version import __version__
+except:
+    __version__ = -1  # decide what to put as a placeholder here
+
+_lock = threading.RLock()
+
+# declare as namespace (older pre PEP 420 approach)
+__path__ = pkgutil.extend_path(__path__, __name__)
+
+EXCLUDE = {"importlib", "pkgutil", "threading"}
+discovered = {
+    name
+    for _, name, ispkg in pkgutil.iter_modules(__path__)
+    if ispkg and not name.startswith("_") and name not in EXCLUDE
+}
+# reproducible ordering
+__all__ = tuple(sorted(discovered))
+
+
+# dynamic and lazy module loading
+def __getattr__(name):
+    with _lock:
+        if name in globals():
+            return globals()[name]
+        try:
+            mod = importlib.import_module(f"{__name__}.{name}")
+        except Exception as e:
+            raise AttributeError(
+                f"Module '{__name__}' has no attribute '{name}' " f"(failed to import '{__name__}.{name}'): {e}"
+            ) from e
+        globals()[name] = mod
+        return mod
+
+
+def __dir__():
+    return tuple(globals()) + __all__

--- a/src/earthkit/__int__.py
+++ b/src/earthkit/__int__.py
@@ -39,7 +39,8 @@ def __getattr__(name):
             mod = importlib.import_module(f"{__name__}.{name}")
         except Exception as e:
             raise AttributeError(
-                f"Module '{__name__}' has no attribute '{name}' " f"(failed to import '{__name__}.{name}'): {e}"
+                f"Module '{__name__}' has no attribute '{name}' "
+                f"(failed to import '{__name__}.{name}'): {e}"
             ) from e
         globals()[name] = mod
         return mod


### PR DESCRIPTION
### Description
Follow-on from https://github.com/ecmwf/earthkit/pull/129. Any earthkit component depending on earthkit-utils will now be able to do `import earthkit as ek; ek.component_name`, implemented with lazy loading.

Also, can we change the default branch for eku to be develop?

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 