### PR TITLE
include earthkit and not just earthkit.utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ urls.Issues = "https://github.com/ecmwf/earthkit-utils.issues"
 urls.Repository = "https://github.com/ecmwf/earthkit-utils/"
 
 [tool.setuptools.packages.find]
-include = [ "earthkit*" ]
+include = [ "earthkit", "earthkit.*" ]
 where = [ "src/" ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
### Description
We need to include `earthkit*` and not just `earthkit.utils` in order to be able to remove the toplevel earthkit `__init__.py` from the main earthkit repo.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 