### PR TITLE
added jax, cupy, torch to downstream-CI reqs

### DIFF
--- a/tests/downstream-ci-requirements.txt
+++ b/tests/downstream-ci-requirements.txt
@@ -3,3 +3,6 @@ pytest-reraise
 xarray
 earthkit-data @ git+https://github.com/ecmwf/earthkit-data@develop
 pint
+cupy
+jax
+torch


### PR DESCRIPTION
### Description

After the `nightly-hpc-gpu` run is fixed now, fixed in the sense it does not error out,
we now want to ensure that GPU code is actually executed.

This change affects also the normal testsuite, if I am not mistaken, as the downstream-ci-requirements.txt is used by all tests by downstream-ci. I actually don't think that's bad, unless the timing drastically increases.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 