### PR TITLE
introduce gpu environment and use that in the HPC GPU test

### DIFF
--- a/.github/ci-hpc-gpu-config.yml
+++ b/.github/ci-hpc-gpu-config.yml
@@ -3,4 +3,4 @@ build:
   parallel: 1
   queue: ng
   gpus: 1
-  toml_opt_dep_sections: all,tests,ci,gpu
+  toml_opt_dep_sections: tests,dev,gpu

--- a/.github/ci-hpc-gpu-config.yml
+++ b/.github/ci-hpc-gpu-config.yml
@@ -3,4 +3,4 @@ build:
   parallel: 1
   queue: ng
   gpus: 1
-  toml_opt_dep_sections: all,tests,ci
+  toml_opt_dep_sections: all,tests,ci,gpu

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,53 @@
+import importlib.util
+
+import pytest
+
+
+def _missing_modules(modules: tuple[str, ...]) -> list[str]:
+    """Return the modules that are not importable."""
+    return [module for module in modules if importlib.util.find_spec(module) is None]
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add CLI option to force optional-dependency tests to run."""
+    parser.addoption(
+        "--run-optional",
+        action="store_true",
+        default=False,
+        help="Run tests even if optional dependencies are missing.",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Auto-add dependency names as plain markers from requires(...)."""
+    for item in items:
+        marker = item.get_closest_marker("requires")
+        if marker is None:
+            continue
+
+        if not marker.args:
+            raise pytest.UsageError(
+                '@pytest.mark.requires needs at least one module name, e.g. @pytest.mark.requires("torch")'
+            )
+
+        for arg in marker.args:
+            item.add_marker(str(arg))
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Skip tests with missing optional dependencies unless forced to run."""
+    marker = item.get_closest_marker("requires")
+    if marker is None:
+        return
+
+    if item.config.getoption("--run-optional"):
+        return
+
+    modules = tuple(str(arg) for arg in marker.args)
+    missing = _missing_modules(modules)
+
+    if missing:
+        pytest.skip("Missing optional dependenc" + ("y" if len(missing) == 1 else "ies") + f": {', '.join(missing)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ optional-dependencies.docs = [
   "sphinx-rtd-theme",
   "sphinx-tabs"
 ]
+optional-dependencies.gpu = [
+  "cupy",
+  "jax",
+  "torch"
+]
 optional-dependencies.test = [
   "earthkit-data",
   "pytest",

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,8 @@ minversion = 7.0
 addopts = -v "--pdbcls=IPython.terminal.debugger:Pdb"
 testpaths =
     tests
+markers =
+    requires(*modules): skip test if one or more Python modules are not installed
+    torch: tests requiring torch
+    cupy: tests requiring cupy
+    jax: tests requiring jax

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ testpaths =
     tests
 markers =
     requires(*modules): skip test if one or more Python modules are not installed
-    torch: tests requiring torch, automatically skipped if torch is not installed and user did not request it explicitly.
-    cupy: tests requiring cupy, automatically skipped if cupy is not installed and user did not request it explicitly.
-    jax: tests requiring jax, automatically skipped if jax is not installed and user did not request it explicitly.
+    torch: tests requiring torch, automatically skipped if torch is not installed.
+    cupy: tests requiring cupy, automatically skipped if cupy is not installed.
+    jax: tests requiring jax, automatically skipped if jax is not installed.
     cuda: tests requiring CUDA support

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ testpaths =
     tests
 markers =
     requires(*modules): skip test if one or more Python modules are not installed
-    torch: tests requiring torch
-    cupy: tests requiring cupy
-    jax: tests requiring jax
+    torch: tests requiring torch, automatically skipped if torch is not installed and user did not request it explicitly.
+    cupy: tests requiring cupy, automatically skipped if cupy is not installed and user did not request it explicitly.
+    jax: tests requiring jax, automatically skipped if jax is not installed and user did not request it explicitly.
     cuda: tests requiring CUDA support

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ markers =
     torch: tests requiring torch
     cupy: tests requiring cupy
     jax: tests requiring jax
+    cuda: tests requiring CUDA support

--- a/src/earthkit/utils/array/testing/testing.py
+++ b/src/earthkit/utils/array/testing/testing.py
@@ -23,24 +23,28 @@ def _modules_installed(*modules):
     return True
 
 
-NO_TORCH = not _modules_installed("torch")
-NO_CUPY = not _modules_installed("cupy")
-NO_JAX = not _modules_installed("jax")
-NO_XARRAY = not _modules_installed("xarray")
-if not NO_CUPY:
+# Marker CUDA
+# Marker MLX
+
+
+TORCH_INSTALLED = _modules_installed("torch")
+CUPY_INSTALLED = _modules_installed("cupy")
+JAX_INSTALLED = _modules_installed("jax")
+XARRAY_INSTALLED = _modules_installed("xarray")
+if CUPY_INSTALLED:
     try:
         import cupy as cp
 
         a = cp.ones(2)
     except Exception:
-        NO_CUPY = True
+        CUPY_INSTALLED = False
 
 ARRAY_NAMES = ["numpy"]
-if not NO_TORCH:
+if TORCH_INSTALLED:
     ARRAY_NAMES.append("torch")
-if not NO_CUPY:
+if CUPY_INSTALLED:
     ARRAY_NAMES.append("cupy")
-# if not NO_JAX:
+# if JAX_INSTALLED:
 #     ARRAY_NAMES.append("jax")
 
 

--- a/tests/test_array_convert.py
+++ b/tests/test_array_convert.py
@@ -13,7 +13,6 @@ import pytest
 
 from earthkit.utils.array import array_namespace, convert
 from earthkit.utils.array.namespace import _CUPY_NAMESPACE, _JAX_NAMESPACE, _NUMPY_NAMESPACE, _TORCH_NAMESPACE
-from earthkit.utils.array.testing.testing import NO_CUPY, NO_JAX, NO_TORCH
 
 # NUMPY
 
@@ -39,14 +38,15 @@ def test_array_convert_numpy_to_numpy():
     _to_numpy_checker(x)
 
 
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.cuda
+@pytest.mark.requires("cupy")
 def test_array_convert_cupy_to_numpy():
     xp = _CUPY_NAMESPACE
     x = xp.asarray([1.0, 2.0, 3.0])
     _to_numpy_checker(x)
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
+@pytest.mark.requires("torch")
 def test_array_convert_torch_to_numpy():
     import torch
 
@@ -82,22 +82,24 @@ def _to_cupy_checker(x):
     # assert xp.device(res) == "cuda:0" # Not implemented yet
 
 
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.cuda
+@pytest.mark.requires("cupy")
 def test_array_convert_cupy_to_cupy():
     xp = _CUPY_NAMESPACE
     x = xp.asarray([1.0, 2.0, 3.0])
     _to_cupy_checker(x)
 
 
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.cuda
+@pytest.mark.requires("cupy")
 def test_array_convert_numpy_to_cupy():
     xp = _NUMPY_NAMESPACE
     x = xp.asarray([1.0, 2.0, 3.0])
     _to_cupy_checker(x)
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.cuda
+@pytest.mark.requires("torch", "cupy")
 def test_array_convert_torch_to_cupy():
     xp = _TORCH_NAMESPACE
     import torch
@@ -142,7 +144,7 @@ def _to_torch_checker(x):
         assert xp.device(res) == torch.device("cuda:0")
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
+@pytest.mark.requires("torch")
 def test_array_convert_torch_to_torch():
     xp = _TORCH_NAMESPACE
     import torch
@@ -159,15 +161,14 @@ def test_array_convert_torch_to_torch():
         _to_torch_checker(x)
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
+@pytest.mark.requires("torch")
 def test_array_convert_numpy_to_torch():
     xp = _NUMPY_NAMESPACE
     x = xp.asarray([1.0, 2.0, 3.0], dtype="float32")
     _to_torch_checker(x)
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.requires("torch", "cupy")
 def test_array_convert_cupy_to_torch():
     xp = _CUPY_NAMESPACE
     x = xp.asarray([1.0, 2.0, 3.0], dtype="float32")
@@ -177,7 +178,7 @@ def test_array_convert_cupy_to_torch():
 # JAX
 
 
-@pytest.mark.skipif(NO_JAX, reason="No jax installed")
+@pytest.mark.requires("jax")
 def test_array_convert_jax_to_jax():
     xp = _JAX_NAMESPACE
     x = xp.asarray([1.0, 2.0, 3.0])

--- a/tests/test_array_namespace.py
+++ b/tests/test_array_namespace.py
@@ -20,7 +20,6 @@ from earthkit.utils.array.namespace import (
     _TORCH_NAMESPACE,
     UnknownPatchedNamespace,
 )
-from earthkit.utils.array.testing.testing import NO_CUPY, NO_JAX, NO_TORCH
 
 
 def test_array_namespace_numpy():
@@ -44,7 +43,7 @@ def test_array_namespace_numpy():
     assert xp.allclose(v_hat, v)
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
+@pytest.mark.requires("torch")
 def test_array_namespace_torch():
     xp = array_namespace("torch")
     assert xp._earthkit_array_namespace_name == "torch"
@@ -65,7 +64,8 @@ def test_array_namespace_torch():
     assert xp.allclose(v_hat, v)
 
 
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.cuda
+@pytest.mark.requires("cupy")
 def test_array_namespace_cupy():
     xp = array_namespace("cupy")
     assert xp._earthkit_array_namespace_name == "cupy"
@@ -86,7 +86,7 @@ def test_array_namespace_cupy():
     assert xp.allclose(v_hat, v)
 
 
-@pytest.mark.skipif(NO_JAX, reason="No jax installed")
+@pytest.mark.requires("jax")
 def test_array_namespace_jax():
     xp = array_namespace("jax")
     assert xp._earthkit_array_namespace_name == "jax"
@@ -137,7 +137,7 @@ def test_patched_namespace_numpy():
     # TODO: test histogramdd and histogram2d
 
 
-@pytest.mark.skipif(NO_TORCH, reason="No torch installed")
+@pytest.mark.requires("torch")
 def test_patched_namespace_torch():
     xp = array_namespace("torch")
     generic_xp = UnknownPatchedNamespace(array_api_compat.torch)
@@ -170,7 +170,7 @@ def test_patched_namespace_torch():
     # TODO: test histogramdd and histogram2d
 
 
-@pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
+@pytest.mark.requires("cupy")
 def test_patched_namespace_cupy():
     xp = array_namespace("cupy")
     generic_xp = UnknownPatchedNamespace(array_api_compat.cupy)
@@ -203,7 +203,7 @@ def test_patched_namespace_cupy():
     # TODO: test histogramdd and histogram2d
 
 
-@pytest.mark.skipif(NO_JAX, reason="No jax installed")
+@pytest.mark.requires("jax")
 def test_patched_namespace_jax():
     xp = array_namespace("jax")
     import jax.numpy as jnp


### PR DESCRIPTION
### Description


After the `nightly-hpc-gpu` run is fixed now, fixed in the sense it does not error out,
we now want to ensure that GPU code is actually executed.

Introduces a `gpu` optional dependency group in the `pyproject.toml`.

Introduces a marker based system for library dependencies and automatic detection if these libraries are installed.

Orthogonally it also introduces markers for GPU devices; currently only cuda.

cleaner version of PR #58


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 