### PR TITLE
feat: add xp.choice

### DIFF
--- a/src/earthkit/utils/array/namespace/cupy.py
+++ b/src/earthkit/utils/array/namespace/cupy.py
@@ -63,6 +63,6 @@ class PatchedCupyNamespace(UnknownPatchedNamespace):
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
 
-    def choice(self, arr, size, replace=True):
-        rng = self.xp.random.default_rng()
-        return rng.choice(arr, size=size, replace=replace)
+    def choice(self, a, size, replace=True, generator=None):
+        rng = self.xp.default_rng() if generator is None else generator
+        return rng.choice(a, size=size, replace=replace)

--- a/src/earthkit/utils/array/namespace/cupy.py
+++ b/src/earthkit/utils/array/namespace/cupy.py
@@ -62,3 +62,7 @@ class PatchedCupyNamespace(UnknownPatchedNamespace):
 
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
+
+    def choice(self, arr, size, replace=True):
+        rng = self.xp.random.default_rng()
+        return rng.choice(arr, size=size, replace=replace)

--- a/src/earthkit/utils/array/namespace/jax.py
+++ b/src/earthkit/utils/array/namespace/jax.py
@@ -35,3 +35,11 @@ class PatchedJaxNamespace(UnknownPatchedNamespace):
 
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
+
+    def choice(self, a, size, replace=True):
+        import jax.random
+
+        if not hasattr(self, "key"):
+            self.key = jax.random.PRNGKey(0)
+        self.key, subkey = jax.random.split(self.key)
+        return jax.random.choice(subkey, a, shape=(size,), replace=replace)

--- a/src/earthkit/utils/array/namespace/jax.py
+++ b/src/earthkit/utils/array/namespace/jax.py
@@ -36,10 +36,10 @@ class PatchedJaxNamespace(UnknownPatchedNamespace):
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
 
-    def choice(self, a, size, replace=True):
+    def choice(self, a, size, replace=True, generator=None):
+        from random import randint
+
         import jax.random
 
-        if not hasattr(self, "key"):
-            self.key = jax.random.PRNGKey(0)
-        self.key, subkey = jax.random.split(self.key)
-        return jax.random.choice(subkey, a, shape=(size,), replace=replace)
+        generator = jax.random.PRNGKey(randint(0, 10000)) if generator is None else generator
+        return jax.random.choice(generator, a, shape=(size,), replace=replace)

--- a/src/earthkit/utils/array/namespace/numpy.py
+++ b/src/earthkit/utils/array/namespace/numpy.py
@@ -52,3 +52,7 @@ class PatchedNumpyNamespace(UnknownPatchedNamespace):
 
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
+
+    def choice(self, a, size, replace=True):
+        rng = self.xp.random.default_rng()
+        return rng.choice(a, size=size, replace=replace)

--- a/src/earthkit/utils/array/namespace/numpy.py
+++ b/src/earthkit/utils/array/namespace/numpy.py
@@ -53,6 +53,6 @@ class PatchedNumpyNamespace(UnknownPatchedNamespace):
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
 
-    def choice(self, a, size, replace=True):
-        rng = self.xp.random.default_rng()
+    def choice(self, a, size, replace=True, generator=None):
+        rng = self.xp.random.default_rng() if generator is None else generator
         return rng.choice(a, size=size, replace=replace)

--- a/src/earthkit/utils/array/namespace/torch.py
+++ b/src/earthkit/utils/array/namespace/torch.py
@@ -59,3 +59,6 @@ class PatchedTorchNamespace(UnknownPatchedNamespace):
 
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
+
+    def choice(self, a, size, replace=True):
+        return self.xp.multinomial(a, size, replacement=replace)

--- a/src/earthkit/utils/array/namespace/torch.py
+++ b/src/earthkit/utils/array/namespace/torch.py
@@ -60,5 +60,9 @@ class PatchedTorchNamespace(UnknownPatchedNamespace):
     def deg2rad(self, x):
         return self.xp.deg2rad(x)
 
-    def choice(self, a, size, replace=True):
-        return self.xp.multinomial(a, size, replacement=replace)
+    def choice(self, a, size, replace=True, generator=None):
+        kwargs = {}
+        if not isinstance(a, int):
+            kwargs["device"] = self.device(a)
+        rng = self.xp.Generator(**kwargs) if generator is None else generator
+        return self.xp.multinomial(a, size, replacement=replace, generator=rng)

--- a/tests/test_array_namespace.py
+++ b/tests/test_array_namespace.py
@@ -23,6 +23,15 @@ from earthkit.utils.array.namespace import (
 from earthkit.utils.array.testing.testing import NO_CUPY, NO_JAX, NO_TORCH
 
 
+def _random_choice(xp):
+    random_samples = xp.choice(xp.arange(10, dtype=float), size=5, replace=False)
+    assert random_samples.shape == (5,)
+    assert len(xp.unique(random_samples)) == len(random_samples)
+    random_samples = xp.choice(xp.arange(2, dtype=float), size=5, replace=True)
+    assert random_samples.shape == (5,)
+    assert len(xp.unique(random_samples)) != len(random_samples)
+
+
 def test_array_namespace_numpy():
     xp = array_namespace("numpy")
     assert xp._earthkit_array_namespace_name == "numpy"
@@ -136,6 +145,8 @@ def test_patched_namespace_numpy():
 
     # TODO: test histogramdd and histogram2d
 
+    _random_choice(xp)
+
 
 @pytest.mark.skipif(NO_TORCH, reason="No torch installed")
 def test_patched_namespace_torch():
@@ -169,6 +180,8 @@ def test_patched_namespace_torch():
 
     # TODO: test histogramdd and histogram2d
 
+    _random_choice(xp)
+
 
 @pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
 def test_patched_namespace_cupy():
@@ -201,6 +214,8 @@ def test_patched_namespace_cupy():
     assert xp.allclose(xp.deg2rad(arr), generic_xp.deg2rad(arr))
 
     # TODO: test histogramdd and histogram2d
+
+    _random_choice(xp)
 
 
 @pytest.mark.skipif(NO_JAX, reason="No jax installed")
@@ -236,6 +251,8 @@ def test_patched_namespace_jax():
     assert xp.allclose(xp.deg2rad(arr), generic_xp.deg2rad(arr))
 
     # TODO: test histogramdd and histogram2d
+
+    _random_choice(xp)
 
 
 if __name__ == "__main__":

--- a/tests/test_array_namespace.py
+++ b/tests/test_array_namespace.py
@@ -23,13 +23,17 @@ from earthkit.utils.array.namespace import (
 from earthkit.utils.array.testing.testing import NO_CUPY, NO_JAX, NO_TORCH
 
 
-def _random_choice(xp):
+def _random_choice(xp, rng1, rng2):
     random_samples = xp.choice(xp.arange(10, dtype=float), size=5, replace=False)
     assert random_samples.shape == (5,)
     assert len(xp.unique(random_samples)) == len(random_samples)
     random_samples = xp.choice(xp.arange(2, dtype=float), size=5, replace=True)
     assert random_samples.shape == (5,)
     assert len(xp.unique(random_samples)) != len(random_samples)
+
+    random_samples1 = xp.choice(xp.arange(10, dtype=float), size=5, replace=False, generator=rng1)
+    random_samples2 = xp.choice(xp.arange(10, dtype=float), size=5, replace=False, generator=rng2)
+    assert xp.allclose(random_samples1, random_samples2)
 
 
 def test_array_namespace_numpy():
@@ -145,7 +149,7 @@ def test_patched_namespace_numpy():
 
     # TODO: test histogramdd and histogram2d
 
-    _random_choice(xp)
+    _random_choice(xp, rng1=xp.random.default_rng(0), rng2=xp.random.default_rng(0))
 
 
 @pytest.mark.skipif(NO_TORCH, reason="No torch installed")
@@ -180,7 +184,12 @@ def test_patched_namespace_torch():
 
     # TODO: test histogramdd and histogram2d
 
-    _random_choice(xp)
+    g1 = xp.Generator()
+    g1.manual_seed(0)
+    g2 = xp.Generator()
+    g2.manual_seed(0)
+
+    _random_choice(xp, rng1=g1, rng2=g2)
 
 
 @pytest.mark.skipif(NO_CUPY, reason="No cupy installed")
@@ -215,7 +224,7 @@ def test_patched_namespace_cupy():
 
     # TODO: test histogramdd and histogram2d
 
-    _random_choice(xp)
+    _random_choice(xp, rng1=xp.random.default_rng(0), rng2=xp.random.default_rng(0))
 
 
 @pytest.mark.skipif(NO_JAX, reason="No jax installed")
@@ -252,7 +261,9 @@ def test_patched_namespace_jax():
 
     # TODO: test histogramdd and histogram2d
 
-    _random_choice(xp)
+    import jax.random
+
+    _random_choice(xp, rng1=jax.random.PRNGKey(0), rng2=jax.random.PRNGKey(0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Add an `xp.choice(a, size, replace=True, generator=None)` method for with or without random sample generation. `a` is either an int, or an array.

Some important caveats/design choices
- I thought it was important to be able to have reproducible random numbers, so this was the workaround I came up with for now with this `generator` kwarg
- do we need a fallback that uses default array-api-compat functions only? Here is just patching per namespace with namespace-specific functions
- thread safety: I think the only way in general is each thread needs its own separate generator. From what I understood, this is also generally the case already and not an earthkit complication on top. I don't see any other way

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
