### PR TITLE
Feat/unshallow rtd clone

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,12 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
   jobs:
+    post_checkout:
+    - git fetch --unshallow || true
     pre_build:
     - rm -rf _build
     - rm -rf docs/_build


### PR DESCRIPTION
### Description

Issue with docs where version is wrong because setuptools_scm cannot find the tags because the clone is shallow. This PR should make the clone no longer shallow, and hence fix the issue

From [rtd docs](https://docs.readthedocs.com/platform/stable/build-customization.html#custom-git-checkout-commands-advanced):
> Read the Docs does not perform a full clone in the checkout job in order to reduce network data and speed up the build process. Instead, it performs a shallow clone and only fetches the branch or tag that you are building documentation for. Because of this, extensions that depend on the full Git history will fail. To avoid this, it’s possible to unshallow the git clone:
> 
> .readthedocs.yaml
> version: 2
> build:
>   os: "ubuntu-24.04"
>   tools:
>     python: "3.10"
>   jobs:
>     post_checkout:
>       - git fetch --unshallow || true

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
